### PR TITLE
[기능 구현] 노트에 대해 CRUD 혹은 칸반 이동 시 연결리스트 적용하여 순서 구현 

### DIFF
--- a/src/main/java/com/example/teampandanback/controller/NoteController.java
+++ b/src/main/java/com/example/teampandanback/controller/NoteController.java
@@ -2,6 +2,7 @@ package com.example.teampandanback.controller;
 
 import com.example.teampandanback.OAuth2.UserDetailsImpl;
 import com.example.teampandanback.dto.note.request.NoteCreateRequestDto;
+import com.example.teampandanback.dto.note.request.NoteMoveRequestDto;
 import com.example.teampandanback.dto.note.request.NoteUpdateRequestDto;
 import com.example.teampandanback.dto.note.response.*;
 import com.example.teampandanback.dto.note.response.NoteSearchInTotalResponseDto;
@@ -58,11 +59,19 @@ public class NoteController {
         return noteService.createNote(projectId, noteCreateRequestDto, userDetails.getUser());
     }
 
-    //노트 수정
-    @ApiOperation(value = "노트 수정")
-    @PutMapping("/notes/{noteId}")
+    //노트 상세 조회에서 수정
+    @ApiOperation(value = "노트 상세 조회에서 수정")
+    @PutMapping("/notes/details/{noteId}")
     public NoteUpdateResponseDto updateNote (@PathVariable("noteId") Long noteId, @RequestBody NoteUpdateRequestDto noteUpdateRequestDto) {
         return noteService.updateNoteDetail(noteId, noteUpdateRequestDto);
+        //  서비스의 메소드명은 변경될수있습니다.
+    }
+
+    //칸반형 조회 화면에서 노트 이동하여 수정
+    @ApiOperation(value = "칸반형 조회 화면에서 노트 이동하여 수정")
+    @PutMapping("/notes/{noteId}")
+    public NoteUpdateResponseDto moveNote (@PathVariable("noteId") Long noteId, @RequestBody NoteMoveRequestDto noteMoveRequestDto) {
+        return noteService.moveNote(noteId, noteMoveRequestDto);
         //  서비스의 메소드명은 변경될수있습니다.
     }
 

--- a/src/main/java/com/example/teampandanback/domain/note/MoveStatus.java
+++ b/src/main/java/com/example/teampandanback/domain/note/MoveStatus.java
@@ -1,0 +1,15 @@
+package com.example.teampandanback.domain.note;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MoveStatus {
+    UNIQUE(0),
+    CURRENTTOP(1),
+    CURRENTBOTTOM(2),
+    CURRENTBETWEEN(3);
+
+    private final int id;
+}

--- a/src/main/java/com/example/teampandanback/domain/note/Note.java
+++ b/src/main/java/com/example/teampandanback/domain/note/Note.java
@@ -45,21 +45,21 @@ public class Note extends Timestamped {
     private Project project;
 
     @Column(name = "PREVIOUS")
-    private Long previous;
+    private Long previousId;
 
     @Column(name = "NEXT")
-    private Long next;
+    private Long nextId;
 
     @Builder
-    public Note(String title, String content, LocalDate deadline, Step step, User user, Project project, Long previous, Long next){
+    public Note(String title, String content, LocalDate deadline, Step step, User user, Project project, Long previousId, Long nextId){
         this.title = title;
         this.content = content;
         this.deadline = deadline;
         this.step = step;
         this.user = user;
         this.project = project;
-        this.previous = previous;
-        this.next = next;
+        this.previousId = previousId;
+        this.nextId = nextId;
     }
 
     public void update(NoteUpdateRequestDto noteUpdateRequestDto, LocalDate updateLocalDate, Step step) {
@@ -69,13 +69,9 @@ public class Note extends Timestamped {
         this.step = step;
     }
 
-    public void updateWhileCreate(Long next) {
-        this.next = next;
-    }
-
-    public void updateWhileMoveNote(Long previous, Long next){
-        this.previous = previous;
-        this.next = next;
+    public void updatePreviousIdAndNextId(Long previousId, Long nextId){
+        this.previousId = previousId;
+        this.nextId = nextId;
     }
 
     public void updateStepWhileMoveNote(Step step){
@@ -83,7 +79,7 @@ public class Note extends Timestamped {
     }
 
 
-        public static Note of(NoteCreateRequestDto noteCreateRequestDto, LocalDate deadline, Step step, User user, Project project, Long previous, Long next) {
+        public static Note of(NoteCreateRequestDto noteCreateRequestDto, LocalDate deadline, Step step, User user, Project project, Long previousId, Long nextId) {
         return Note.builder()
                 .title(noteCreateRequestDto.getTitle())
                 .content(noteCreateRequestDto.getContent())
@@ -91,8 +87,8 @@ public class Note extends Timestamped {
                 .step(step)
                 .user(user)
                 .project(project)
-                .previous(previous)
-                .next(next)
+                .previousId(previousId)
+                .nextId(nextId)
                 .build();
     }
 }

--- a/src/main/java/com/example/teampandanback/domain/note/Note.java
+++ b/src/main/java/com/example/teampandanback/domain/note/Note.java
@@ -44,33 +44,38 @@ public class Note extends Timestamped {
     @JoinColumn(name = "PROJECT_ID")
     private Project project;
 
+    @Column(name = "PREVIOUS")
+    private Long previous;
+
+    @Column(name = "NEXT")
+    private Long next;
 
     @Builder
-    public Note(String title, String content, LocalDate deadline, Step step, User user, Project project){
+    public Note(String title, String content, LocalDate deadline, Step step, User user, Project project, Long previous, Long next){
         this.title = title;
         this.content = content;
         this.deadline = deadline;
         this.step = step;
         this.user = user;
         this.project = project;
+        this.previous = previous;
+        this.next = next;
     }
 
-    // #1
-    // What: Note.java에서 changeType 메소드를 삭제하고, update 메소드는 형변환이 완료된 LocalDate 파라미터를 받게 하였습니다.
-    // Why: NoteService.java 에서 형변환이 자주 일어나는 바, NoteService.java 에서 형변환 메소드를 정적으로 정의하여 공용으로 쓰기 위함입니다.
-    // How: NoteService의 updateNoteDetail 함수는 전달받은 noteRequestDto의 String을 꺼내 localDate으로 변환 후 여기에 전달합니다.
-    public void update(NoteUpdateRequestDto noteUpdateRequestDto, LocalDate updateLocalDate, Step step) {
+    public void update(NoteUpdateRequestDto noteUpdateRequestDto, LocalDate updateLocalDate, Step step, Long previous, Long next) {
         this.title = noteUpdateRequestDto.getTitle();
         this.content = noteUpdateRequestDto.getContent();
         this.deadline = updateLocalDate;
         this.step = step;
+        this.previous = previous;
+        this.next = next;
     }
 
-    // #2
-    // What: of 메소드를 만들어서 dto를
-    // Why: 서비스에서
-    // How:
-    public static Note of(NoteCreateRequestDto noteCreateRequestDto, LocalDate deadline, Step step, User user, Project project) {
+    public void updateWhileCreate(Long next) {
+        this.next = next;
+    }
+
+    public static Note of(NoteCreateRequestDto noteCreateRequestDto, LocalDate deadline, Step step, User user, Project project, Long previous, Long next) {
         return Note.builder()
                 .title(noteCreateRequestDto.getTitle())
                 .content(noteCreateRequestDto.getContent())
@@ -78,6 +83,8 @@ public class Note extends Timestamped {
                 .step(step)
                 .user(user)
                 .project(project)
+                .previous(previous)
+                .next(next)
                 .build();
     }
 }

--- a/src/main/java/com/example/teampandanback/domain/note/Note.java
+++ b/src/main/java/com/example/teampandanback/domain/note/Note.java
@@ -62,11 +62,10 @@ public class Note extends Timestamped {
         this.nextId = nextId;
     }
 
-    public void update(NoteUpdateRequestDto noteUpdateRequestDto, LocalDate updateLocalDate, Step step) {
+    public void update(NoteUpdateRequestDto noteUpdateRequestDto, LocalDate updateLocalDate) {
         this.title = noteUpdateRequestDto.getTitle();
         this.content = noteUpdateRequestDto.getContent();
         this.deadline = updateLocalDate;
-        this.step = step;
     }
 
     public void updatePreviousIdAndNextId(Long previousId, Long nextId){

--- a/src/main/java/com/example/teampandanback/domain/note/Note.java
+++ b/src/main/java/com/example/teampandanback/domain/note/Note.java
@@ -73,6 +73,14 @@ public class Note extends Timestamped {
         this.nextId = nextId;
     }
 
+    public void updatePreviousId(Long previousId){
+        this.previousId = previousId;
+    }
+
+    public void updateNextId(Long nextId){
+        this.nextId = nextId;
+    }
+
     public void updateStepWhileMoveNote(Step step){
         this.step = step;
     }

--- a/src/main/java/com/example/teampandanback/domain/note/Note.java
+++ b/src/main/java/com/example/teampandanback/domain/note/Note.java
@@ -62,20 +62,28 @@ public class Note extends Timestamped {
         this.next = next;
     }
 
-    public void update(NoteUpdateRequestDto noteUpdateRequestDto, LocalDate updateLocalDate, Step step, Long previous, Long next) {
+    public void update(NoteUpdateRequestDto noteUpdateRequestDto, LocalDate updateLocalDate, Step step) {
         this.title = noteUpdateRequestDto.getTitle();
         this.content = noteUpdateRequestDto.getContent();
         this.deadline = updateLocalDate;
         this.step = step;
-        this.previous = previous;
-        this.next = next;
     }
 
     public void updateWhileCreate(Long next) {
         this.next = next;
     }
 
-    public static Note of(NoteCreateRequestDto noteCreateRequestDto, LocalDate deadline, Step step, User user, Project project, Long previous, Long next) {
+    public void updateWhileMoveNote(Long previous, Long next){
+        this.previous = previous;
+        this.next = next;
+    }
+
+    public void updateStepWhileMoveNote(Step step){
+        this.step = step;
+    }
+
+
+        public static Note of(NoteCreateRequestDto noteCreateRequestDto, LocalDate deadline, Step step, User user, Project project, Long previous, Long next) {
         return Note.builder()
                 .title(noteCreateRequestDto.getTitle())
                 .content(noteCreateRequestDto.getContent())

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepository.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepository.java
@@ -15,8 +15,6 @@ public interface NoteRepository extends JpaRepository<Note,Long>, NoteRepository
     // Project 에 연관된 Note 조회
     List<Note> findByProject(Project project);
 
-    Optional<Note> findByPreviousAndNext(Long previous, Long next);
-
     @Query("select note from Note note where note.project.projectId = :projectId and note.step = :step")
     List<Note> findAllByProjectAndStep(@Param("projectId") Long projectId, @Param("step") Step step);
 

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepository.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note,Long>, NoteRepositoryQuerydsl {
 //    List<Note> findAllByProject(Long projectId);
@@ -14,6 +15,8 @@ public interface NoteRepository extends JpaRepository<Note,Long>, NoteRepository
     // Project 에 연관된 Note 조회
     List<Note> findByProject(Project project);
     List<Note> findAllByProjectOrderByCreatedAtDesc(Project project);
+
+    Optional<Note> findByPreviousAndNext(Long previous, Long next);
 
     @Query("select note from Note note where note.project.projectId = :projectId and note.step = :step")
     List<Note> findAllByProjectAndStep(@Param("projectId") Long projectId, @Param("step") Step step);

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepository.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepository.java
@@ -3,6 +3,7 @@ package com.example.teampandanback.domain.note;
 import com.example.teampandanback.domain.project.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,6 +14,9 @@ public interface NoteRepository extends JpaRepository<Note,Long>, NoteRepository
     // Project 에 연관된 Note 조회
     List<Note> findByProject(Project project);
     List<Note> findAllByProjectOrderByCreatedAtDesc(Project project);
+
+    @Query("select note from Note note where note.project.projectId = :projectId and note.step = :step")
+    List<Note> findAllByProjectAndStep(@Param("projectId") Long projectId, @Param("step") Step step);
 
     // Project 에 연관된 Note 삭제
     void deleteByProject_ProjectId(Long projectId);

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryImpl.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.example.teampandanback.dto.note.response.NoteEachMineInTotalResponseD
 import com.example.teampandanback.dto.note.response.noteEachSearchInTotalResponseDto;
 import com.example.teampandanback.dto.note.response.NoteResponseDto;
 import com.example.teampandanback.dto.note.response.NoteEachSearchInMineResponseDto;
+import com.example.teampandanback.exception.ApiRequestException;
 import com.example.teampandanback.utils.PandanUtils;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
@@ -130,6 +131,15 @@ public class NoteRepositoryImpl implements NoteRepositoryQuerydsl{
                 .where(note.user.userId.eq(userId).and(builder))
                 .orderBy(note.modifiedAt.desc())
                 .join(note.project, project)
+                .fetch();
+    }
+
+    @Override
+    public List<Note> findNotesByNoteIdList(List<Long> noteIdList) {
+        return queryFactory
+                .selectFrom(note)
+                .where(note.noteId.in(noteIdList))
+                .orderBy(note.step.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryQuerydsl.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryQuerydsl.java
@@ -21,4 +21,5 @@ public interface NoteRepositoryQuerydsl {
     List<Note> findAllNoteByProjectAndUserOrderByCreatedAtDesc(Long projectId, Long userId);
     List<noteEachSearchInTotalResponseDto> findNotesByUserIdAndKeywordInTotal(Long userId, List<String> kewordList);
     List<NoteEachSearchInMineResponseDto> findNotesByUserIdAndKeywordInMine(Long userId, List<String> kewordList);
+    List<Note> findNotesByNoteIdList(List<Long> noteIdList);
 }

--- a/src/main/java/com/example/teampandanback/domain/note/Step.java
+++ b/src/main/java/com/example/teampandanback/domain/note/Step.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Step {
-    STORAGE(1, "창고"),
-    TODO(2, "할것"),
-    PROCESSING(3, "진행중"),
-    DONE(4, "끝");
+    STORAGE(0, "창고"),
+    TODO(1, "할것"),
+    PROCESSING(2, "진행중"),
+    DONE(3, "끝");
 
     private final int id;
     private final String step;

--- a/src/main/java/com/example/teampandanback/domain/user_project_mapping/UserProjectMappingRepository.java
+++ b/src/main/java/com/example/teampandanback/domain/user_project_mapping/UserProjectMappingRepository.java
@@ -12,16 +12,8 @@ import java.util.Optional;
 
 public interface UserProjectMappingRepository extends JpaRepository<UserProjectMapping, Long>, UserProjectMappingRepositoryQuerydsl {
 
-    UserProjectMapping findByUser_UserIdAndProject_ProjectId(Long userId, Long projectId); // but 갑자기 join함. 쿼리보면 갑분쪼
-
-    void deleteByProject_ProjectId(Long projectId);
-
-//    UserProjectMapping findByUser_IdAndProject_Id(Long userId, Long projectId);
-//
-//    void deleteByProject_Id(Long projectId);
-
-    @Query("select upm from UserProjectMapping upm join fetch upm.user where upm.project = ?1")
-    List<UserProjectMapping> findAllByProject(Project project);
+    @Query("select upm from UserProjectMapping upm join fetch upm.user where upm.project = :project")
+    List<UserProjectMapping> findAllByProject(@Param("project") Project project);
 
     Optional<UserProjectMapping> findByUserAndProject(User newCrew, Project invitedProject);
 

--- a/src/main/java/com/example/teampandanback/dto/note/request/NoteCreateRequestDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/request/NoteCreateRequestDto.java
@@ -8,5 +8,4 @@ public class NoteCreateRequestDto {
     private String content;
     private String deadline;
     private String step;
-    private Long previousNoteId;
 }

--- a/src/main/java/com/example/teampandanback/dto/note/request/NoteCreateRequestDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/request/NoteCreateRequestDto.java
@@ -8,4 +8,5 @@ public class NoteCreateRequestDto {
     private String content;
     private String deadline;
     private String step;
+    private Long previous;
 }

--- a/src/main/java/com/example/teampandanback/dto/note/request/NoteMoveRequestDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/request/NoteMoveRequestDto.java
@@ -8,8 +8,8 @@ public class NoteMoveRequestDto {
     private String content;
     private String deadline;
     private String step;
-    private Long originPreNoteId;
-    private Long originNextNoteId;
-    private Long goalPreNoteId;
-    private Long goalNextNoteId;
+    private Long fromPreNoteId;
+    private Long fromNextNoteId;
+    private Long toPreNoteId;
+    private Long toNextNodeId;
 }

--- a/src/main/java/com/example/teampandanback/dto/note/request/NoteMoveRequestDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/request/NoteMoveRequestDto.java
@@ -4,9 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class NoteMoveRequestDto {
-    private String title;
-    private String content;
-    private String deadline;
     private String step;
     private Long fromPreNoteId;
     private Long fromNextNoteId;

--- a/src/main/java/com/example/teampandanback/dto/note/request/NoteMoveRequestDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/request/NoteMoveRequestDto.java
@@ -3,10 +3,13 @@ package com.example.teampandanback.dto.note.request;
 import lombok.Getter;
 
 @Getter
-public class NoteCreateRequestDto {
+public class NoteMoveRequestDto {
     private String title;
     private String content;
     private String deadline;
     private String step;
-    private Long previousNoteId;
+    private Long originPreNoteId;
+    private Long originNextNoteId;
+    private Long goalPreNoteId;
+    private Long goalNextNoteId;
 }

--- a/src/main/java/com/example/teampandanback/dto/note/request/NoteUpdateRequestDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/request/NoteUpdateRequestDto.java
@@ -7,5 +7,4 @@ public class NoteUpdateRequestDto {
     private String title;
     private String content;
     private String deadline;
-    private String step;
 }

--- a/src/main/java/com/example/teampandanback/dto/note/response/NoteUpdateResponseDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/response/NoteUpdateResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 public class NoteUpdateResponseDto {
@@ -14,14 +15,19 @@ public class NoteUpdateResponseDto {
     private String content;
     private String deadline;
     private String step;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 
     @Builder
-    public NoteUpdateResponseDto(Long noteId, String title, String content, LocalDate deadline, Step step) {
+    public NoteUpdateResponseDto(Long noteId, String title, String content, LocalDate deadline, Step step,
+                                 LocalDateTime createdAt, LocalDateTime modifiedAt) {
         this.noteId = noteId;
         this.title = title;
         this.content = content;
         this.deadline = deadline.toString();
         this.step = step.toString();
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
     }
 
     public static NoteUpdateResponseDto of (Note note) {
@@ -31,6 +37,8 @@ public class NoteUpdateResponseDto {
                 .content(note.getContent())
                 .deadline(note.getDeadline())
                 .step(note.getStep())
+                .createdAt(note.getCreatedAt())
+                .modifiedAt(note.getModifiedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/teampandanback/service/NoteService.java
+++ b/src/main/java/com/example/teampandanback/service/NoteService.java
@@ -19,6 +19,7 @@ import com.example.teampandanback.dto.note.response.noteEachSearchInTotalRespons
 import com.example.teampandanback.dto.note.response.NoteSearchInTotalResponseDto;
 import com.example.teampandanback.exception.ApiRequestException;
 import com.example.teampandanback.utils.PandanUtils;
+import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -246,6 +247,23 @@ public class NoteService {
 
         // Note 에 연관된 북마크 삭제
         bookmarkRepository.deleteByNote(noteId);
+
+        Note previousNote = noteRepository.findById(note.getPrevious()).orElse(null);
+        Note nextNote = noteRepository.findById(note.getNext()).orElse(null);
+
+        try{
+            previousNote.updateWhileMoveNote(previousNote.getPrevious(), nextNote.getNoteId());
+        }
+        catch (Exception e){
+            throw new ApiRequestException(e.toString());
+        }
+
+        try{
+            nextNote.updateWhileMoveNote(previousNote.getNoteId(), nextNote.getNext());
+        }
+        catch (Exception e){
+            throw new ApiRequestException(e.toString());
+        }
 
         // Note 삭제
         noteRepository.delete(note);

--- a/src/main/java/com/example/teampandanback/service/NoteService.java
+++ b/src/main/java/com/example/teampandanback/service/NoteService.java
@@ -69,23 +69,22 @@ public class NoteService {
     // Note 작성
     @Transactional
     public NoteCreateResponseDto createNote(Long projectId, NoteCreateRequestDto noteCreateRequestDto, SessionUser sessionUser) {
-        Optional<UserProjectMapping> userProjectMapping =
-                userProjectMappingRepository
-                        .findByUserIdAndProjectId(sessionUser.getUserId(), projectId);
-        if(!userProjectMapping.isPresent()){
-            throw new ApiRequestException("해당 유저가 해당 프로젝트에 참여해있지 않습니다.");
-        }
+        UserProjectMapping userProjectMapping = userProjectMappingRepository
+                        .findByUserIdAndProjectId(sessionUser.getUserId(), projectId)
+                        .orElseThrow(()-> new ApiRequestException("해당 유저가 해당 프로젝트에 참여해있지 않습니다."));
 
         // [노트 생성] 전달받은 String deadline을 LocalDate 자료형으로 형변환
         LocalDate deadline = pandanUtils.changeType(noteCreateRequestDto.getDeadline());
         // [노트 생성] 전달받은 String step을 Enum Step으로
         Step step = Step.valueOf(noteCreateRequestDto.getStep());
         // [노트 생성] 찾은 userProjectMappingRepository를 통해 user와 프로젝트 가져오기
-        User user = userProjectMapping.get().getUser();
-        Project project = userProjectMapping.get().getProject();
+        User user = userProjectMapping.getUser();
+        Project project = userProjectMapping.getProject();
 
         // 현재 프로젝트의 해당 스텝에 있는 노트 리스트를 가져온 후 가장 마지막 노트를 찾는다.
-        Note lastNote = noteRepository.findAllByProjectAndStep(projectId, step)
+        // 조건을 만족하지 않는다면 lastNote 값에 그 다음의 if문 조건절 비교를 위해 null 넣어준다.
+        Note lastNote = noteRepository
+                .findAllByProjectAndStep(projectId, step)
                 .stream()
                 .filter(each -> each.getNext().equals(0L))
                 .findFirst().orElse(null);
@@ -93,21 +92,22 @@ public class NoteService {
         // lastNote 있고 noteCreateRequestDto previous 값과 일치한다면
         if(lastNote != null && lastNote.getNoteId().equals(noteCreateRequestDto.getPrevious())){
             // [노트 생성] 전달받은 noteCreateRequestDto를 Note.java에 정의한 of 메소드에 전달하여 빌더 패턴에 넣는다.
-            Note note = noteRepository.save(Note.of(noteCreateRequestDto, deadline, step, user, project, lastNote.getNoteId(), 0L));
+            Note note = noteRepository
+                    .save(Note.of(noteCreateRequestDto, deadline, step, user, project, lastNote.getNoteId(), 0L));
             // lastNote의 Next 값을 현재 생성된 노트의 ID로 변경해준다.
             lastNote.updateWhileCreate(note.getNoteId());
             return NoteCreateResponseDto.of(note);
         }
         // lastNote 없고 noteCreateRequestDto previous 값도 0이 맞다면
         else if(lastNote == null && noteCreateRequestDto.getPrevious() == 0){
-            // [노트 생성] 전달받은 noteCreateRequestDto를 Note.java에 정의한 of 메소드에 전달하여 빌더 패턴에 넣는다.
-            Note note = noteRepository.save(Note.of(noteCreateRequestDto, deadline, step, user, project, 0L, 0L));
-            // preNote 가 없으므로 따로 처리해주지 않는다.
-            return NoteCreateResponseDto.of(note);
+            // lastNote 가 없으므로 바로 저장한다.
+            return NoteCreateResponseDto.of(noteRepository.save(Note.of(noteCreateRequestDto, deadline, step, user, project, 0L, 0L)));
         }
-        // lastNote 없는데 noteCreateRequestDto prvious 값은 0이 아니라면
+        // lastNote 없는데 noteCreateRequestDto prvious 값은 0이 아니거나 다른 값이라면
+        // lastNote 있는데 previous 값은 0 내지는 값이 다르다면
+        // 사용자의 칸반이 새로고침 되어야.. 싱크 맞지 않는 것 -> 웹소켓 문제로 이어진다.
         else{
-            throw new ApiRequestException("잘못된 요청입니다.");
+            throw new ApiRequestException("새로고침 이후 다시 시도해주세요.");
         }
     }
 

--- a/src/main/java/com/example/teampandanback/service/NoteService.java
+++ b/src/main/java/com/example/teampandanback/service/NoteService.java
@@ -255,14 +255,14 @@ public class NoteService {
             previousNote.updateWhileMoveNote(previousNote.getPrevious(), nextNote.getNoteId());
         }
         catch (Exception e){
-            throw new ApiRequestException(e.toString());
+            log.info(e.toString());
         }
 
         try{
             nextNote.updateWhileMoveNote(previousNote.getNoteId(), nextNote.getNext());
         }
         catch (Exception e){
-            throw new ApiRequestException(e.toString());
+            log.info(e.toString());
         }
 
         // Note 삭제

--- a/src/main/java/com/example/teampandanback/service/NoteService.java
+++ b/src/main/java/com/example/teampandanback/service/NoteService.java
@@ -124,7 +124,7 @@ public class NoteService {
                 break;
         }
 
-        // Step 이동이든 아니든 DynamicUpdate에 의해서 이동한 경우만 반영하게 된다. 민서님 고마워요! bb
+        // Step 이동이든 아니든 DynamicUpdate에 의해서 이동한 경우만 반영하게 된다.
         currentNote.updateStepWhileMoveNote(Step.valueOf(noteMoveRequestDto.getStep()));
         return NoteUpdateResponseDto.of(currentNote);
     }

--- a/src/main/java/com/example/teampandanback/service/NoteService.java
+++ b/src/main/java/com/example/teampandanback/service/NoteService.java
@@ -72,7 +72,7 @@ public class NoteService {
         Note currentNote = noteRepository.findById(noteId).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
 
         // 옮기기 전 step에서의 노트 간 연결이 db와 같은지 확인
-        if (!currentNote.getPrevious().equals(noteMoveRequestDto.getOriginPreNoteId()) || !currentNote.getNext().equals(noteMoveRequestDto.getOriginNextNoteId())) {
+        if (!currentNote.getPreviousId().equals(noteMoveRequestDto.getOriginPreNoteId()) || !currentNote.getNextId().equals(noteMoveRequestDto.getOriginNextNoteId())) {
             throw new ApiRequestException("새로고침 후 시도해주세요");
         }
 
@@ -82,28 +82,28 @@ public class NoteService {
             if (noteMoveRequestDto.getGoalPreNoteId() != 0L && noteMoveRequestDto.getGoalNextNoteId() != 0L) {
                 Note goalPreNote = noteRepository.findById(noteMoveRequestDto.getGoalPreNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
                 Note goalNextNote = noteRepository.findById(noteMoveRequestDto.getGoalNextNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
-                if (goalPreNote.getNext().equals(noteMoveRequestDto.getGoalNextNoteId())) {
-                    goalPreNote.updateWhileMoveNote(goalPreNote.getPrevious(), currentNote.getNoteId());
-                    currentNote.updateWhileMoveNote(goalPreNote.getNoteId(), goalNextNote.getNoteId());
+                if (goalPreNote.getNextId().equals(noteMoveRequestDto.getGoalNextNoteId())) {
+                    goalPreNote.updatePreviousIdAndNextId(goalPreNote.getPreviousId(), currentNote.getNoteId());
+                    currentNote.updatePreviousIdAndNextId(goalPreNote.getNoteId(), goalNextNote.getNoteId());
                     currentNote.updateStepWhileMoveNote(goalPreNote.getStep());
-                    goalNextNote.updateWhileMoveNote(currentNote.getNoteId(), goalNextNote.getNext());
+                    goalNextNote.updatePreviousIdAndNextId(currentNote.getNoteId(), goalNextNote.getNextId());
                 } else {
                     throw new ApiRequestException("새로고침 후 시도해주세요.");
                 }
             } else if (noteMoveRequestDto.getGoalPreNoteId() == 0L && noteMoveRequestDto.getGoalNextNoteId() != 0L) {
                 Note goalNextNote = noteRepository.findById(noteMoveRequestDto.getGoalNextNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
-                if (goalNextNote.getPrevious().equals(0L)) {
-                    currentNote.updateWhileMoveNote(0L, goalNextNote.getNoteId());
+                if (goalNextNote.getPreviousId().equals(0L)) {
+                    currentNote.updatePreviousIdAndNextId(0L, goalNextNote.getNoteId());
                     currentNote.updateStepWhileMoveNote(goalNextNote.getStep());
-                    goalNextNote.updateWhileMoveNote(currentNote.getNoteId(), goalNextNote.getNext());
+                    goalNextNote.updatePreviousIdAndNextId(currentNote.getNoteId(), goalNextNote.getNextId());
                 } else {
                     throw new ApiRequestException("새로고침 후 시도해주세요.");
                 }
             } else if (noteMoveRequestDto.getGoalPreNoteId() != 0L && noteMoveRequestDto.getGoalNextNoteId() == 0L) {
                 Note goalPreNote = noteRepository.findById(noteMoveRequestDto.getGoalPreNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
-                if (goalPreNote.getNext().equals(0L)) {
-                    goalPreNote.updateWhileMoveNote(goalPreNote.getPrevious(), currentNote.getNext());
-                    currentNote.updateWhileMoveNote(goalPreNote.getNoteId(), 0L);
+                if (goalPreNote.getNextId().equals(0L)) {
+                    goalPreNote.updatePreviousIdAndNextId(goalPreNote.getPreviousId(), currentNote.getNextId());
+                    currentNote.updatePreviousIdAndNextId(goalPreNote.getNoteId(), 0L);
                     currentNote.updateStepWhileMoveNote(goalPreNote.getStep());
                 } else {
                     throw new ApiRequestException("새로고침 후 시도해주세요.");
@@ -113,7 +113,7 @@ public class NoteService {
             else {
                 List<Note> resultList = noteRepository.findAllByProjectAndStep(currentNote.getProject().getProjectId(), Step.valueOf(noteMoveRequestDto.getStep()));
                 if (resultList.size() == 0) {
-                    currentNote.updateWhileMoveNote(0L, 0L);
+                    currentNote.updatePreviousIdAndNextId(0L, 0L);
                     currentNote.updateStepWhileMoveNote(Step.valueOf(noteMoveRequestDto.getStep()));
                 }
             }
@@ -124,26 +124,26 @@ public class NoteService {
             if (noteMoveRequestDto.getGoalPreNoteId() != 0L && noteMoveRequestDto.getGoalNextNoteId() != 0L) {
                 Note goalPreNote = noteRepository.findById(noteMoveRequestDto.getGoalPreNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
                 Note goalNextNote = noteRepository.findById(noteMoveRequestDto.getGoalNextNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
-                if (goalPreNote.getNext().equals(noteMoveRequestDto.getGoalNextNoteId())) {
-                    goalPreNote.updateWhileMoveNote(goalPreNote.getPrevious(), currentNote.getNoteId());
-                    currentNote.updateWhileMoveNote(goalPreNote.getNoteId(), goalNextNote.getNoteId());
-                    goalNextNote.updateWhileMoveNote(currentNote.getNoteId(), goalNextNote.getNext());
+                if (goalPreNote.getNextId().equals(noteMoveRequestDto.getGoalNextNoteId())) {
+                    goalPreNote.updatePreviousIdAndNextId(goalPreNote.getPreviousId(), currentNote.getNoteId());
+                    currentNote.updatePreviousIdAndNextId(goalPreNote.getNoteId(), goalNextNote.getNoteId());
+                    goalNextNote.updatePreviousIdAndNextId(currentNote.getNoteId(), goalNextNote.getNextId());
                 } else {
                     throw new ApiRequestException("새로고침 후 시도해주세요.");
                 }
             } else if (noteMoveRequestDto.getGoalPreNoteId() == 0L && noteMoveRequestDto.getGoalNextNoteId() != 0L) {
                 Note goalNextNote = noteRepository.findById(noteMoveRequestDto.getGoalNextNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
-                if (goalNextNote.getPrevious().equals(0L)) {
-                    currentNote.updateWhileMoveNote(0L, goalNextNote.getNoteId());
-                    goalNextNote.updateWhileMoveNote(currentNote.getNoteId(), goalNextNote.getNext());
+                if (goalNextNote.getPreviousId().equals(0L)) {
+                    currentNote.updatePreviousIdAndNextId(0L, goalNextNote.getNoteId());
+                    goalNextNote.updatePreviousIdAndNextId(currentNote.getNoteId(), goalNextNote.getNextId());
                 } else {
                     throw new ApiRequestException("새로고침 후 시도해주세요.");
                 }
             } else if (noteMoveRequestDto.getGoalPreNoteId() != 0L && noteMoveRequestDto.getGoalNextNoteId() == 0L) {
                 Note goalPreNote = noteRepository.findById(noteMoveRequestDto.getGoalPreNoteId()).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
-                if (goalPreNote.getNext().equals(0L)) {
-                    goalPreNote.updateWhileMoveNote(goalPreNote.getPrevious(), currentNote.getNext());
-                    currentNote.updateWhileMoveNote(goalPreNote.getNoteId(), 0L);
+                if (goalPreNote.getNextId().equals(0L)) {
+                    goalPreNote.updatePreviousIdAndNextId(goalPreNote.getPreviousId(), currentNote.getNextId());
+                    currentNote.updatePreviousIdAndNextId(goalPreNote.getNoteId(), 0L);
                 } else {
                     throw new ApiRequestException("새로고침 후 시도해주세요.");
                 }
@@ -157,51 +157,39 @@ public class NoteService {
     }
 
     // Note 작성
-    // TODO pre와 next 순서가 바뀌고, 프론트 request가 이제 아무것도 보내주지 않아도 그냥 내가 찾아서 계산한다.
     @Transactional
     public NoteCreateResponseDto createNote(Long projectId, NoteCreateRequestDto noteCreateRequestDto, User currentUser) {
+
         UserProjectMapping userProjectMapping = userProjectMappingRepository
                 .findByUserIdAndProjectId(currentUser.getUserId(), projectId)
                 .orElseThrow(() -> new ApiRequestException("해당 프로젝트에 소속된 유저가 아닙니다."));
 
-        // [노트 생성] 전달받은 String deadline을 LocalDate 자료형으로 형변환
         LocalDate deadline = pandanUtils.changeType(noteCreateRequestDto.getDeadline());
-        // [노트 생성] 전달받은 String step을 Enum Step으로
         Step step = Step.valueOf(noteCreateRequestDto.getStep());
-        // [노트 생성] 찾은 userProjectMappingRepository를 통해 user와 프로젝트 가져오기
         User user = userProjectMapping.getUser();
         Project project = userProjectMapping.getProject();
 
-        // 현재 프로젝트의 해당 스텝에 있는 노트 리스트를 가져온 후 가장 마지막 노트를 찾는다.
-        // 조건을 만족하지 않는다면 lastNote 값에 그 다음의 if문 조건절 비교를 위해 null 넣어준다.
-        Note lastNote = noteRepository
-                .findAllByProjectAndStep(projectId, step)
+        // Project로 전체 노트 리스트 가져오기
+        List<Note> rawNoteList = noteRepository.findByProject(project);
+
+        // topNoteList로부터 topNote 찾기, 없다면 null 넣는다.
+        Note topNote = pandanUtils.getTopNoteList(rawNoteList)
                 .stream()
-                .filter(each -> each.getNext().equals(0L))
+                .filter(note -> note.getStep().equals(step))
                 .findFirst().orElse(null);
 
-        // lastNote 있고 noteCreateRequestDto next 값과 일치한다면
-        if (lastNote != null && lastNote.getNoteId().equals(noteCreateRequestDto.getPreviousNoteId())) {
-            // [노트 생성] 전달받은 noteCreateRequestDto를 Note.java에 정의한 of 메소드에 전달하여 빌더 패턴에 넣는다.
-            Note note = noteRepository
-                    .save(Note
-                            .of(noteCreateRequestDto, deadline, step, user, project, lastNote.getNoteId(), 0L));
-            // lastNote의 Next 값을 현재 생성된 노트의 ID로 변경해준다.
-            lastNote.updateWhileCreate(note.getNoteId());
-            return NoteCreateResponseDto.of(note);
+        // topNote가 있다면, topNote의 pre와 next 바꿔주고 dtoNote 저장한다.
+        if (topNote != null) {
+            Note savedNote = noteRepository.save(Note
+                    .of(noteCreateRequestDto, deadline, step, user, project, topNote.getNoteId(), 0L));
+            topNote.updatePreviousIdAndNextId(topNote.getPreviousId(), savedNote.getNoteId());
+            return NoteCreateResponseDto.of(savedNote);
         }
-        // lastNote 없고 noteCreateRequestDto previous 값도 0이 맞다면
-        else if (lastNote == null && noteCreateRequestDto.getPreviousNoteId() == 0L) {
-            // lastNote 가 없으므로 바로 저장한다.
+        // topNote 없다면, 그냥 저장한다
+        else {
             return NoteCreateResponseDto
                     .of(noteRepository.save(Note
                             .of(noteCreateRequestDto, deadline, step, user, project, 0L, 0L)));
-        }
-        // lastNote 없는데 noteCreateRequestDto prvious 값은 0이 아니거나 다른 값이라면
-        // lastNote 있는데 previous 값은 0 내지는 값이 다르다면
-        // 사용자의 칸반이 새로고침 되어야.. 싱크 맞지 않는 것 -> 웹소켓 문제로 이어진다.
-        else {
-            throw new ApiRequestException("새로고침 이후 다시 시도해주세요.");
         }
     }
 
@@ -216,7 +204,7 @@ public class NoteService {
         // 해당 Project 에서 내가 작성한 Note 죄회
         List<NoteReadMineEachResponseDto> myNoteList =
                 noteRepository.findAllNoteByProjectAndUserOrderByCreatedAtDesc(
-                        projectId, currentUser.getUserId(), PandanUtils.dealWithPageRequestParam(page, size))
+                        projectId, currentUser.getUserId(), pandanUtils.dealWithPageRequestParam(page, size))
                         .stream()
                         .map(NoteReadMineEachResponseDto::fromEntity)
                         .collect(Collectors.toList());
@@ -230,7 +218,7 @@ public class NoteService {
         // 해당 북마크한 Note 조회
         List<NoteEachBookmarkedResponseDto> noteEachBookmarkedResponseDto =
                 bookmarkRepository.findNoteByUserIdInBookmark(
-                        currentUser.getUserId(), PandanUtils.dealWithPageRequestParam(page, size));
+                        currentUser.getUserId(), pandanUtils.dealWithPageRequestParam(page, size));
 
         return NoteBookmarkedResponseDto.builder().noteList(noteEachBookmarkedResponseDto).build();
     }
@@ -249,17 +237,17 @@ public class NoteService {
         // Note 에 연관된 북마크 삭제
         bookmarkRepository.deleteByNote(noteId);
 
-        Note previousNote = noteRepository.findById(note.getPrevious()).orElse(null);
-        Note nextNote = noteRepository.findById(note.getNext()).orElse(null);
+        Note previousNote = noteRepository.findById(note.getPreviousId()).orElse(null);
+        Note nextNote = noteRepository.findById(note.getNextId()).orElse(null);
 
         try {
-            previousNote.updateWhileMoveNote(previousNote.getPrevious(), nextNote.getNoteId());
+            previousNote.updatePreviousIdAndNextId(previousNote.getPreviousId(), nextNote.getNoteId());
         } catch (Exception e) {
             log.info(e.toString());
         }
 
         try {
-            nextNote.updateWhileMoveNote(previousNote.getNoteId(), nextNote.getNext());
+            nextNote.updatePreviousIdAndNextId(previousNote.getNoteId(), nextNote.getNextId());
         } catch (Exception e) {
             log.info(e.toString());
         }
@@ -281,54 +269,26 @@ public class NoteService {
                 () -> new ApiRequestException("칸반을 조회할 프로젝트가 없습니다.")
         );
 
-        List<NoteOfProjectResponseDto> noteOfProjectResponseDtoList = new ArrayList<>();
-        List<KanbanNoteEachResponseDto> kanbanNoteEachResponseDtoList1 = new ArrayList<>();
-        List<KanbanNoteEachResponseDto> kanbanNoteEachResponseDtoList2 = new ArrayList<>();
-        List<KanbanNoteEachResponseDto> kanbanNoteEachResponseDtoList3 = new ArrayList<>();
-        List<KanbanNoteEachResponseDto> kanbanNoteEachResponseDtoList4 = new ArrayList<>();
-
         // Project로 전체 노트 리스트 가져오기
         List<Note> rawNoteList = noteRepository.findByProject(project);
-        // BottomPointer를 담기 위한 리스트
-        List<Note> bottomPointerList = new ArrayList<>();
 
-        // Stream을 못쓰는 것은 아쉽지만 순회를 1번으로 줄이기 위해서 for문을 사용한다.
-        // rawMap에 (PK, Note) 의 형태로 저장되어 객체 그래프의 역할을 할 수 있게
-        Map<Long, Note> rawMap = new HashMap<>();
-        for (Note note : rawNoteList) {
-            rawMap.put(note.getNoteId(), note);
-            if (note.getPrevious() == 0L) {
-                bottomPointerList.add(note);
-            }
-        }
+        // topNoteList 만들기, <PK,Note> 해쉬맵 만들기 (실은 순회 한 번에 할 수 있음, 지금은 2번) -> 수정 시 재사용 가능
+        List<Note> topNoteList = pandanUtils.getTopNoteList(rawNoteList);
+        Map<Long, Note> rawMap = pandanUtils.getRawMap(rawNoteList);
 
-        for (Note bottomPointer : bottomPointerList) {
-            Note pointer = bottomPointer;
-            while (pointer != null) {
-                Note target = rawMap.get(pointer.getNoteId());
-                switch (pointer.getStep()) {
-                    case STORAGE:
-                        kanbanNoteEachResponseDtoList1.add(KanbanNoteEachResponseDto.of(target));
-                        break;
-                    case TODO:
-                        kanbanNoteEachResponseDtoList2.add(KanbanNoteEachResponseDto.of(target));
-                        break;
-                    case PROCESSING:
-                        kanbanNoteEachResponseDtoList3.add(KanbanNoteEachResponseDto.of(target));
-                        break;
-                    case DONE:
-                        kanbanNoteEachResponseDtoList4.add(KanbanNoteEachResponseDto.of(target));
-                        break;
-                }
-                pointer = rawMap.get(target.getNext());
-            }
-        }
+        //각 스텝 별 노트리스트를 담은 통합 리스트 연결리스트 순서에 맞게 재구성하여 가져온다
+        List<List<KanbanNoteEachResponseDto>> resultList = pandanUtils.getResultList(topNoteList, rawMap);
 
         // Note 를 각 상태별로 List 로 묶어서 응답 보내기
-        noteOfProjectResponseDtoList.add(NoteOfProjectResponseDto.of(Step.STORAGE, kanbanNoteEachResponseDtoList1));
-        noteOfProjectResponseDtoList.add(NoteOfProjectResponseDto.of(Step.TODO, kanbanNoteEachResponseDtoList2));
-        noteOfProjectResponseDtoList.add(NoteOfProjectResponseDto.of(Step.PROCESSING, kanbanNoteEachResponseDtoList3));
-        noteOfProjectResponseDtoList.add(NoteOfProjectResponseDto.of(Step.DONE, kanbanNoteEachResponseDtoList4));
+        List<NoteOfProjectResponseDto> noteOfProjectResponseDtoList = new ArrayList<>();
+
+        // Step 별로 순회돌기 위해서 리스트 만들기
+        List<Step> stepList = new ArrayList<>(Arrays.asList(Step.STORAGE, Step.TODO, Step.PROCESSING, Step.DONE));
+
+        // Step 별로 순회돌며 스텝 별 리스트에 resultList에 스텝 순서에 맞춰 들어간 정보를 가져온다
+        for (Step step : stepList) {
+            noteOfProjectResponseDtoList.add(NoteOfProjectResponseDto.of(step, resultList.get(step.getId())));
+        }
 
         return KanbanNoteSearchResponseDto.builder()
                 .noteOfProjectResponseDtoList(noteOfProjectResponseDtoList)
@@ -347,7 +307,7 @@ public class NoteService {
 
 
         for (Note note : noteRepository.findAllByProjectOrderByCreatedAtDesc(
-                project, PandanUtils.dealWithPageRequestParam(page, size))) {
+                project, pandanUtils.dealWithPageRequestParam(page, size))) {
             ordinaryNoteEachResponseDtoList.add((OrdinaryNoteEachResponseDto.fromEntity(note)));
         }
 
@@ -358,16 +318,18 @@ public class NoteService {
     public NoteMineInTotalResponseDto readMyNoteInTotalProject(User currentUser, int page, int size) {
         List<NoteEachMineInTotalResponseDto> resultList =
                 noteRepository.findUserNoteInTotalProject(
-                        currentUser.getUserId(), PandanUtils.dealWithPageRequestParam(page, size));
+                        currentUser.getUserId(), pandanUtils.dealWithPageRequestParam(page, size));
         return NoteMineInTotalResponseDto.builder().myNoteList(resultList).build();
     }
 
+    // 내가 소속된 프로젝트에서 제목으로 노트 검색
     public NoteSearchInTotalResponseDto searchNoteInMyProjects(User currentUser, String rawKeyword) {
         List<String> keywordList = pandanUtils.parseKeywordToList(rawKeyword);
         List<noteEachSearchInTotalResponseDto> resultList = noteRepository.findNotesByUserIdAndKeywordInTotal(currentUser.getUserId(), keywordList);
         return NoteSearchInTotalResponseDto.builder().noteList(resultList).build();
     }
 
+    // 내가 작성한 문서들 중에서 제목으로 노트 검색
     public NoteSearchInMineResponseDto searchNoteInMyNotes(User currentUser, String rawKeyword) {
         List<String> keywordList = pandanUtils.parseKeywordToList(rawKeyword);
         List<NoteEachSearchInMineResponseDto> resultList = noteRepository.findNotesByUserIdAndKeywordInMine(currentUser.getUserId(), keywordList);

--- a/src/main/java/com/example/teampandanback/utils/PandanUtils.java
+++ b/src/main/java/com/example/teampandanback/utils/PandanUtils.java
@@ -199,4 +199,20 @@ public class PandanUtils {
 
         return moveStatuses;
     }
+
+    // 승연: 4가지 deleteStatus 중 현재 상황이 어떤 것인지 정하기 위한 메소드입니다.
+    public MoveStatus getDeleteStatus(Long previousId, Long nextId){
+        if (previousId == 0L && nextId == 0L){
+            return MoveStatus.UNIQUE;
+        }
+        else if (previousId != 0L && nextId == 0L){
+            return MoveStatus.CURRENTTOP;
+        }
+        else if (previousId == 0L && nextId != 0L){
+            return MoveStatus.CURRENTBOTTOM;
+        }
+        else{
+            return MoveStatus.CURRENTBETWEEN;
+        }
+    }
 }

--- a/src/main/java/com/example/teampandanback/utils/PandanUtils.java
+++ b/src/main/java/com/example/teampandanback/utils/PandanUtils.java
@@ -1,5 +1,7 @@
 package com.example.teampandanback.utils;
 
+import com.example.teampandanback.domain.note.Note;
+import com.example.teampandanback.dto.note.response.KanbanNoteEachResponseDto;
 import com.example.teampandanback.exception.ApiRequestException;
 import com.querydsl.core.BooleanBuilder;
 import org.springframework.data.domain.PageRequest;
@@ -7,25 +9,23 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.example.teampandanback.domain.note.QNote.note;
 
 @Component
 public class PandanUtils {
 
-    // String 자료형으로 받은 날짜를 LocalDate 자료형으로 형변환
+
+    // 승연: String 자료형으로 받은 날짜를 LocalDate 자료형으로 형변환
     public LocalDate changeType(String dateString) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         LocalDate date = LocalDate.parse(dateString, formatter);
         return date;
     }
 
-
-    // 검색을 위해 받은 keyword를 적절한 조건으로 parsing 하여 List 형태로 반환
+    // 승연: 검색을 위해 받은 keyword를 적절한 조건으로 parsing 하여 List 형태로 반환
     public List<String> parseKeywordToList(String rawKeyword){
         List<String> rawKeywordList = Arrays.asList(rawKeyword.split(" "));
         List<String> parsedKeywordList = new ArrayList<>();
@@ -44,7 +44,7 @@ public class PandanUtils {
         return parsedKeywordList;
     }
 
-    //QueryDSL 검색 시 where 절에 조건을 추가하는 BooleanBuilder 메소드입니다
+    // 승연: QueryDSL 검색 시 where 절에 조건을 추가하는 BooleanBuilder 메소드입니다
     public BooleanBuilder searchByTitleBooleanBuilder(List<String> keywordList) {
         BooleanBuilder builder = new BooleanBuilder();
         for(String keyword : keywordList){
@@ -53,10 +53,67 @@ public class PandanUtils {
         return builder;
     }
 
-    public static PageRequest dealWithPageRequestParam(int page, int size) {
+    // 성경:
+    public PageRequest dealWithPageRequestParam(int page, int size) {
         PageRequest pageRequest = PageRequest
                 .of((page <= 0 ? 1 : page)-1, (size <= 0 ? 1 : size));
         return pageRequest;
+    }
+
+    // 승연: 칸반형 목록에서 topPointerList 만들기 위한 메소드입니다. - 승연
+    public List<Note> getTopNoteList(List<Note> rawNoteList){
+        return rawNoteList
+                .stream()
+                .filter(note->note.getNextId().toString().equals("0"))
+                .collect(Collectors.toList());
+    }
+
+    // 승연: <PK,Note> 해쉬맵 만들어서 PK로 노트를 바로 찾을 수 있게 하기 위한 HashMap을 만드는 메소드입니다.
+    public Map<Long, Note> getRawMap(List<Note> rawNoteList){
+        return rawNoteList
+                .stream()
+                .collect(Collectors.toMap(Note::getNoteId, note -> note));
+    }
+
+    // 승연: topPointer와 프로젝트 노트가 담긴 HashMap으로 스텝 별 노트를 연결 리스트 로직에 맞추어 재구성합니다.
+    public List<List<KanbanNoteEachResponseDto>> getResultList(List<Note> topNoteList, Map<Long, Note> rawMap){
+
+        List<List<KanbanNoteEachResponseDto>> resultList = new ArrayList<>();
+
+        // 각 스텝 별 노트를 담을 리스트 만들기
+        List<KanbanNoteEachResponseDto> StorageNoteList = new ArrayList<>();
+        List<KanbanNoteEachResponseDto> TodoNoteList = new ArrayList<>();
+        List<KanbanNoteEachResponseDto> ProcessingNoteList = new ArrayList<>();
+        List<KanbanNoteEachResponseDto> DoneNoteList = new ArrayList<>();
+
+        for (Note topNote : topNoteList) {
+            Note pointer = topNote;
+            while (pointer != null) {
+                Note target = rawMap.get(pointer.getNoteId());
+                switch (pointer.getStep()) {
+                    case STORAGE:
+                        StorageNoteList.add(KanbanNoteEachResponseDto.of(target));
+                        break;
+                    case TODO:
+                        TodoNoteList.add(KanbanNoteEachResponseDto.of(target));
+                        break;
+                    case PROCESSING:
+                        ProcessingNoteList.add(KanbanNoteEachResponseDto.of(target));
+                        break;
+                    case DONE:
+                        DoneNoteList.add(KanbanNoteEachResponseDto.of(target));
+                        break;
+                }
+                pointer = rawMap.get(target.getPreviousId());
+            }
+        }
+
+        resultList.add(StorageNoteList);
+        resultList.add(TodoNoteList);
+        resultList.add(ProcessingNoteList);
+        resultList.add(DoneNoteList);
+
+        return resultList;
     }
 
 }

--- a/src/main/java/com/example/teampandanback/utils/PandanUtils.java
+++ b/src/main/java/com/example/teampandanback/utils/PandanUtils.java
@@ -1,6 +1,8 @@
 package com.example.teampandanback.utils;
 
+import com.example.teampandanback.domain.note.MoveStatus;
 import com.example.teampandanback.domain.note.Note;
+import com.example.teampandanback.dto.note.request.NoteMoveRequestDto;
 import com.example.teampandanback.dto.note.response.KanbanNoteEachResponseDto;
 import com.example.teampandanback.exception.ApiRequestException;
 import com.querydsl.core.BooleanBuilder;
@@ -17,6 +19,12 @@ import static com.example.teampandanback.domain.note.QNote.note;
 @Component
 public class PandanUtils {
 
+    // 성경:
+    public PageRequest dealWithPageRequestParam(int page, int size) {
+        PageRequest pageRequest = PageRequest
+                .of((page <= 0 ? 1 : page) - 1, (size <= 0 ? 1 : size));
+        return pageRequest;
+    }
 
     // 승연: String 자료형으로 받은 날짜를 LocalDate 자료형으로 형변환
     public LocalDate changeType(String dateString) {
@@ -26,18 +34,18 @@ public class PandanUtils {
     }
 
     // 승연: 검색을 위해 받은 keyword를 적절한 조건으로 parsing 하여 List 형태로 반환
-    public List<String> parseKeywordToList(String rawKeyword){
+    public List<String> parseKeywordToList(String rawKeyword) {
         List<String> rawKeywordList = Arrays.asList(rawKeyword.split(" "));
         List<String> parsedKeywordList = new ArrayList<>();
 
-        for (String each: rawKeywordList){
+        for (String each : rawKeywordList) {
             // blank가 아니어야 하고, each의 길이가 2 이상이거나, 전체 단어의 수가 2이상이면
-            if(each.length() > 1 || rawKeywordList.size() > 1 && !each.equals(" ")){
+            if (each.length() > 1 || rawKeywordList.size() > 1 && !each.equals(" ")) {
                 parsedKeywordList.add(each.toLowerCase(Locale.ROOT));
             }
         }
 
-        if (parsedKeywordList.size() == 0){
+        if (parsedKeywordList.size() == 0) {
             throw new ApiRequestException("검색 조건에 부합하지 않습니다.");
         }
 
@@ -47,36 +55,29 @@ public class PandanUtils {
     // 승연: QueryDSL 검색 시 where 절에 조건을 추가하는 BooleanBuilder 메소드입니다
     public BooleanBuilder searchByTitleBooleanBuilder(List<String> keywordList) {
         BooleanBuilder builder = new BooleanBuilder();
-        for(String keyword : keywordList){
+        for (String keyword : keywordList) {
             builder.and(note.title.toLowerCase().contains(keyword));
         }
         return builder;
     }
 
-    // 성경:
-    public PageRequest dealWithPageRequestParam(int page, int size) {
-        PageRequest pageRequest = PageRequest
-                .of((page <= 0 ? 1 : page)-1, (size <= 0 ? 1 : size));
-        return pageRequest;
-    }
-
-    // 승연: 칸반형 목록에서 topPointerList 만들기 위한 메소드입니다. - 승연
-    public List<Note> getTopNoteList(List<Note> rawNoteList){
+    // 승연: 칸반형 목록에서 topPointerList 만들기 위한 메소드입니다.
+    public List<Note> getTopNoteList(List<Note> rawNoteList) {
         return rawNoteList
                 .stream()
-                .filter(note->note.getNextId().toString().equals("0"))
+                .filter(note -> note.getNextId().toString().equals("0"))
                 .collect(Collectors.toList());
     }
 
     // 승연: <PK,Note> 해쉬맵 만들어서 PK로 노트를 바로 찾을 수 있게 하기 위한 HashMap을 만드는 메소드입니다.
-    public Map<Long, Note> getRawMap(List<Note> rawNoteList){
+    public Map<Long, Note> getRawMap(List<Note> rawNoteList) {
         return rawNoteList
                 .stream()
                 .collect(Collectors.toMap(Note::getNoteId, note -> note));
     }
 
     // 승연: topPointer와 프로젝트 노트가 담긴 HashMap으로 스텝 별 노트를 연결 리스트 로직에 맞추어 재구성합니다.
-    public List<List<KanbanNoteEachResponseDto>> getResultList(List<Note> topNoteList, Map<Long, Note> rawMap){
+    public List<List<KanbanNoteEachResponseDto>> getResultList(List<Note> topNoteList, Map<Long, Note> rawMap) {
 
         List<List<KanbanNoteEachResponseDto>> resultList = new ArrayList<>();
 
@@ -116,4 +117,86 @@ public class PandanUtils {
         return resultList;
     }
 
+    // 승연: 수정 시 동시성 문제가 일어나기 전에 DB와 프론트 요청의 싱크를 확인합니다.
+    public Boolean checkSync(Long noteId, NoteMoveRequestDto noteMoveRequestDto,
+                             List<Note> rawNoteList, Map<Long, Note> rawMap) {
+        // from 연결 관계 검증 조건문
+        if (rawMap.get(noteId).getPreviousId().equals(noteMoveRequestDto.getFromPreNoteId())
+                && rawMap.get(noteId).getNextId().equals(noteMoveRequestDto.getFromNextNoteId())) {
+
+            // from 연결 관계가 맞고, front 요청에서 ToNextNoteId 존재한다고 하여
+            if (noteMoveRequestDto.getToNextNodeId() != 0L) {
+
+                // 실제로 DB에서도 그렇다면 true, 아니라면 false
+                return rawMap.get(noteMoveRequestDto.getToNextNodeId()).getPreviousId().equals(noteMoveRequestDto.getToPreNoteId());
+            }
+
+            // from 연결 관계가 맞고, front 요청에서 ToPreNote 존재한다고 하여
+            if (noteMoveRequestDto.getToPreNoteId() != 0L) {
+
+                // 실제로 DB에서도 그렇다면 true, 아니라면 false
+                return rawMap.get(noteMoveRequestDto.getToPreNoteId()).getNextId().equals(noteMoveRequestDto.getToNextNodeId());
+            }
+
+            // from 연결 관계가 맞고, To에 아무것도 없다고 하는 주장이
+            if (noteMoveRequestDto.getToPreNoteId() == 0L && noteMoveRequestDto.getToNextNodeId() == 0L){
+
+                // 해당 step의 topNote가 없는 것으로 실제 맞는 것이 확인되면 true, 아니라면 false
+                Note topNote = null;
+
+                for (Note note1 : getTopNoteList(rawNoteList)) {
+                    if (note1.getStep().toString().equals(noteMoveRequestDto.getStep())) {
+                        topNote = note1;
+                        break;
+                    }
+                }
+
+                // 위의 과정이 끝나고서도 null 이 맞다면 true
+                return topNote == null;
+            }
+
+        }
+        // from 연결 관계 틀렸다면 false
+        else {
+            return false;
+        }
+
+        // 모든 검증에서 false 없이 왔으면 true
+        return true;
+    }
+
+    // 승연: 16가지 moveStatus 중 현재 상황이 어떤 것인지 정하기 위한 메소드입니다.
+    public MoveStatus[] getMoveStatus(NoteMoveRequestDto noteMoveRequestDto){
+        MoveStatus[] moveStatuses = new MoveStatus[2];
+
+        // From의 status 정한다.
+        if (noteMoveRequestDto.getFromPreNoteId() == 0L && noteMoveRequestDto.getFromNextNoteId() == 0L){
+            moveStatuses[0] = MoveStatus.UNIQUE;
+        }
+        else if (noteMoveRequestDto.getFromPreNoteId() != 0L && noteMoveRequestDto.getFromNextNoteId() == 0L){
+            moveStatuses[0] = MoveStatus.CURRENTTOP;
+        }
+        else if (noteMoveRequestDto.getFromPreNoteId() == 0L && noteMoveRequestDto.getFromNextNoteId() != 0L){
+            moveStatuses[0] = MoveStatus.CURRENTBOTTOM;
+        }
+        else{
+            moveStatuses[0] = MoveStatus.CURRENTBETWEEN;
+        }
+
+        // To의 status 정한다.
+        if (noteMoveRequestDto.getToPreNoteId() == 0L && noteMoveRequestDto.getToNextNodeId() == 0L){
+            moveStatuses[1] = MoveStatus.UNIQUE;
+        }
+        else if (noteMoveRequestDto.getToPreNoteId() != 0L && noteMoveRequestDto.getToNextNodeId() == 0L){
+            moveStatuses[1] = MoveStatus.CURRENTTOP;
+        }
+        else if (noteMoveRequestDto.getToPreNoteId() == 0L && noteMoveRequestDto.getToNextNodeId() != 0L){
+            moveStatuses[1] = MoveStatus.CURRENTBOTTOM;
+        }
+        else{
+            moveStatuses[1] = MoveStatus.CURRENTBETWEEN;
+        }
+
+        return moveStatuses;
+    }
 }


### PR DESCRIPTION
1. 상세 조회에서 수정하는 경우 적용하지 않고, 노트 이동과 구분하여 api를 하나 더 구현했습니다.
2. 노트 이동 시 순서 적용
3. 노트 삭제 시 순서 적용
4. 노트 생성 시 순서 적용

@mangdo @Code-Angler @BlossomWhale
#74 (comment) 를 참고하시면 자주 등장하는 Enum 클래스나 노트 이동 시의 로직을 원활하게 파악하실 수 있습니다.