### PR TITLE
프로젝트 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/example/teampandanback/controller/ProjectController.java
+++ b/src/main/java/com/example/teampandanback/controller/ProjectController.java
@@ -86,7 +86,7 @@ public class ProjectController {
         return projectService.readCrewList(projectId);
     }
 
-    //프로젝트 참여
+    // Project 참여
     @ApiOperation(value = "프로젝트 참여" , notes = "회원초대코드로 참여하게 됨")
     @PostMapping("/invites")
     public ProjectInvitedResponseDto invited(@RequestBody ProjectInvitedRequestDto projectInvitedRequestDto,
@@ -94,12 +94,16 @@ public class ProjectController {
         return projectService.invitedProject(projectInvitedRequestDto,userDetails.getUser());
     }
 
-    //프로젝트 탈퇴
-//    @ApiOperation(value = "프로젝트 탈퇴")
-//    @PostMapping("/un-invite/{projectId}")
-//    public void unInvite(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal UserDetailsImpl userDetails){
-//        projectService.unInviteProject(projectId,userDetails.getUser());
-//    }
+    // Project 탈퇴
+    @ApiOperation(value = "프로젝트 탈퇴", notes = "프로젝트의 CREW만 나갈 수 있습니다. OWNER는 나가지 못합니다.")
+    @PutMapping("/leave/{projectId}")
+    public ProjectLeaveResponseDto unInvite(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal UserDetailsImpl userDetails){
+        projectService.leaveProject(projectId,userDetails.getUser());
+
+        return ProjectLeaveResponseDto.builder()
+                .projectId(projectId)
+                .build();
+    }
 
 
 }

--- a/src/main/java/com/example/teampandanback/domain/bookmark/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/example/teampandanback/domain/bookmark/BookmarkRepositoryImpl.java
@@ -122,4 +122,21 @@ public class BookmarkRepositoryImpl implements BookmarkRepositoryQuerydsl {
                 .groupBy(note.project.projectId)
                 .fetch();
     }
+
+    // 해당 프로젝트내에서 유저가 북마크 했던 기록 삭제
+    @Override
+    public void deleteByProjectIdAndUserId(Long projectId, Long userId) {
+        queryFactory
+                .delete(bookmark)
+                .where(
+                        bookmark.user.userId.eq(userId),
+                        bookmark.note.noteId.in(
+                                JPAExpressions
+                                        .select(note.noteId)
+                                        .from(note)
+                                        .where(note.project.projectId.eq(projectId))
+                        )
+                )
+                .execute();
+    }
 }

--- a/src/main/java/com/example/teampandanback/domain/bookmark/BookmarkRepositoryQuerydsl.java
+++ b/src/main/java/com/example/teampandanback/domain/bookmark/BookmarkRepositoryQuerydsl.java
@@ -26,4 +26,9 @@ public interface BookmarkRepositoryQuerydsl {
 
     // 유저가 가진 프로젝트들의 북마크 정보 조회
     List<BookmarkDetailForProjectListDto> findBookmarkCountByProject(List<Long> projectIdList, Long userId);
+
+    // 해당 프로젝트내에서 유저가 북마크 했던 기록 삭제
+    @Modifying(clearAutomatically = true)
+    void deleteByProjectIdAndUserId(Long projectId, Long userId);
+
 }

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryImpl.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryImpl.java
@@ -69,7 +69,9 @@ public class NoteRepositoryImpl implements NoteRepositoryQuerydsl {
 
     // 전체 프로젝트 중 해당 유저가 작성한 노트 조회
     @Override
-    public CustomPageImpl<NoteEachMineInTotalResponseDto> findUserNoteInTotalProject(Long userId, Pageable pageable) {
+    public CustomPageImpl<NoteEachMineInTotalResponseDto> findUserNoteInTotalProject(
+            Long userId, Pageable pageable, List<Long> projectIdList) {
+
         QueryResults<NoteEachMineInTotalResponseDto> results =
                 queryFactory
                         .select(
@@ -78,8 +80,8 @@ public class NoteRepositoryImpl implements NoteRepositoryQuerydsl {
                                 ))
                         .from(note)
                         .join(note.project, project)
-                        .where(note.user.userId.eq(userId))
-                        .orderBy(note.modifiedAt.desc())
+                        .where(note.user.userId.eq(userId), note.project.projectId.in(projectIdList))
+                        .orderBy(note.createdAt.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetchResults();
@@ -94,6 +96,7 @@ public class NoteRepositoryImpl implements NoteRepositoryQuerydsl {
                 .execute();
     }
 
+    // 해당 Project 에서 유저가 작성한 Note 조회
     @Override
     public CustomPageImpl<Note> findAllNoteByProjectAndUserOrderByCreatedAtDesc(Long projectId, Long userId,
                                                                                 Pageable pageable) {
@@ -102,7 +105,7 @@ public class NoteRepositoryImpl implements NoteRepositoryQuerydsl {
                         .select(note)
                         .from(note)
                         .where(note.project.projectId.eq(projectId).and(note.user.userId.eq(userId)))
-                        .orderBy(note.modifiedAt.desc())
+                        .orderBy(note.createdAt.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetchResults();
@@ -127,21 +130,24 @@ public class NoteRepositoryImpl implements NoteRepositoryQuerydsl {
                 .join(note.project, project)
                 .join(note.user, user)
                 .where(note.project.projectId.in(projectIdList).and(builder))
-                .orderBy(note.modifiedAt.desc())
+                .orderBy(note.createdAt.desc())
                 .fetch();
     }
 
     // keyword로 내가 쓴 문서 안에서 노트 검색, 제목으로만 검색합니다.
+    // 내가 썼고, 지금 내가 참여하고 있는 프로젝트 안에 있는 노트를 대상으로 검색합니다.
     @Override
-    public List<NoteEachSearchInMineResponseDto> findNotesByUserIdAndKeywordInMine(Long userId, List<String> keywordList) {
+    public List<NoteEachSearchInMineResponseDto> findNotesByUserIdAndKeywordInMine(Long userId, List<String> keywordList, List<Long> projectIdList) {
         BooleanBuilder builder = pandanUtils.searchByTitleBooleanBuilder(keywordList);
 
         return queryFactory
                 .select(Projections.constructor(NoteEachSearchInMineResponseDto.class,
                         note.noteId, note.title, note.step, project.projectId, project.title, note.createdAt))
                 .from(note)
-                .where(note.user.userId.eq(userId).and(builder))
-                .orderBy(note.modifiedAt.desc())
+                .where(note.user.userId.eq(userId)
+                        .and(note.project.projectId.in(projectIdList)
+                        .and(builder)))
+                .orderBy(note.createdAt.desc())
                 .join(note.project, project)
                 .fetch();
     }

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryQuerydsl.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryQuerydsl.java
@@ -19,16 +19,18 @@ public interface NoteRepositoryQuerydsl {
     Optional<NoteResponseDto> findByNoteId(Long noteId);
 
     // 전체 프로젝트에서 해당 유저가 작성한 노트 조회
-    CustomPageImpl<NoteEachMineInTotalResponseDto> findUserNoteInTotalProject(Long userId, Pageable pageable); // findByUserId()
+    CustomPageImpl<NoteEachMineInTotalResponseDto> findUserNoteInTotalProject(Long userId, Pageable pageable, List<Long> projectIdList); // findByUserId()
 
     @Modifying(clearAutomatically = true)
     void deleteByProjectId(Long projectId);
 
+    // 해당 Project 에서 유저가 작성한 Note 조회
     CustomPageImpl<Note> findAllNoteByProjectAndUserOrderByCreatedAtDesc(Long projectId, Long userId, Pageable pageable);
 
-    List<noteEachSearchInTotalResponseDto> findNotesByUserIdAndKeywordInTotal(Long userId, List<String> kewordList);
+    List<noteEachSearchInTotalResponseDto> findNotesByUserIdAndKeywordInTotal(Long userId, List<String> keywordList);
 
-    List<NoteEachSearchInMineResponseDto> findNotesByUserIdAndKeywordInMine(Long userId, List<String> kewordList);
+    // 내가 작성한 문서들 중에서 제목으로 노트 검색
+    List<NoteEachSearchInMineResponseDto> findNotesByUserIdAndKeywordInMine(Long userId, List<String> keywordList, List<Long> projectIdList);
 
     List<Note> findNotesByNoteIdList(List<Long> noteIdList);
 

--- a/src/main/java/com/example/teampandanback/domain/user_project_mapping/UserProjectMappingRepositoryImpl.java
+++ b/src/main/java/com/example/teampandanback/domain/user_project_mapping/UserProjectMappingRepositoryImpl.java
@@ -143,4 +143,15 @@ public class UserProjectMappingRepositoryImpl implements UserProjectMappingRepos
                 .where(userProjectMapping.project.projectId.eq(projectId))
                 .fetchCount();
     }
+
+    // 유저가 참여해 있는 모든 프로젝트들의 ID 목록을 조회
+    @Override
+    public List<Long> findProjectIdListByUserId(Long userId) {
+
+        return queryFactory
+                .select(userProjectMapping.project.projectId)
+                .from(userProjectMapping)
+                .where(userProjectMapping.user.userId.eq(userId))
+                .fetch();
+    }
 }

--- a/src/main/java/com/example/teampandanback/domain/user_project_mapping/UserProjectMappingRepositoryQuerydsl.java
+++ b/src/main/java/com/example/teampandanback/domain/user_project_mapping/UserProjectMappingRepositoryQuerydsl.java
@@ -28,6 +28,9 @@ public interface UserProjectMappingRepositoryQuerydsl {
     //x 유저가 참여해있는 모든 유저-프로젝트를 호출
     List<UserProjectMapping> findByUserId(Long userId);
 
+    // x 유저가 참여해 있는 모든 프로젝트들의 ID 목록을 조회
+    List<Long> findProjectIdListByUserId(Long userId);
+
     UserProjectMapping findByUserIdAndProjectIdJoin(Long userId, Long projectId);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/example/teampandanback/dto/project/response/ProjectLeaveResponseDto.java
+++ b/src/main/java/com/example/teampandanback/dto/project/response/ProjectLeaveResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.teampandanback.dto.project.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ProjectLeaveResponseDto {
+    // 프로젝트 탈퇴시 반환하는 Dto
+
+    // 탈퇴한 프로젝트 ID
+    private Long projectId;
+
+    @Builder
+    public ProjectLeaveResponseDto(Long projectId) {
+        this.projectId = projectId;
+    }
+}

--- a/src/main/java/com/example/teampandanback/service/ProjectService.java
+++ b/src/main/java/com/example/teampandanback/service/ProjectService.java
@@ -288,18 +288,20 @@ public class ProjectService {
         return userProjectMappingRepository.findProjectListTopSize(currentUser.getUserId(), sidebarSize);
     }
 
-//    //프로젝트 탈퇴
-//    public void unInviteProject(Long projectId, User user) {
-//        UserProjectMapping userProjectMapping = userProjectMappingRepository.findByUserIdAndProjectId(user.getUserId(), projectId).orElseThrow(
-//                () -> new ApiRequestException("참여하지 않은 프로젝트에서 탈퇴하려 합니다.")
-//        );
-//
-//        Long countedUserAtThisProject = userProjectMappingRepository.countByProjectId(projectId);
-//
-//        if(countedUserAtThisProject <= 1L){
-//
-//        }
-//
-//        userProjectMappingRepository.delete(userProjectMapping);
-//    }
+
+    // Project 에서 탈퇴하기
+    @Transactional
+    public void leaveProject(Long projectId, User user) {
+        UserProjectMapping userProjectMapping = userProjectMappingRepository.findByUserIdAndProjectId(user.getUserId(), projectId).orElseThrow(
+                () -> new ApiRequestException("참여하지 않은 프로젝트에서 탈퇴하려 합니다.")
+        );
+        // 해당 유저가 OWNER 라면 탈퇴할 수 없다
+        if(userProjectMapping.getRole().equals(UserProjectRole.OWNER)){
+            throw new ApiRequestException("프로젝트의 OWNER 는 프로젝트를 탈퇴할 수 없습니다!");
+        }
+        // 해당 프로젝트내에서 유저가 북마크 했던 기록 삭제
+        bookmarkRepository.deleteByProjectIdAndUserId(projectId, user.getUserId());
+
+        userProjectMappingRepository.deleteById(userProjectMapping.getSeq());
+    }
 }


### PR DESCRIPTION
1. 프로젝트 탈퇴 기능 구현하였습니다! [#107 ]
- OWNER는 탈퇴할 수 없습니다. OWNER는 대신 프로젝트를 삭제할 수 있습니다.
- 프로젝트에서 탈퇴하게 되면?
   -  유저가 해당 프로젝트 내에서 북마크 했던 기록을 모두 삭제합니다.
   -  유저가 해당 프로젝트에 썼었던 노트는 더 이상 조회/검색할 수 없습니다.
   
- 검색에서의 변화
   - 내가 북마크한 노트 내에서
             : 나갈 때 북마크 다 삭제함 수정 필요x!
   - 내가 작성한 문서 내에서
              : **수정 했음** -> 해당 프로젝트에 참여하고 있는지를 where 조건에 추가
   - 내가 참여하고 있는 전체 프로젝트내에서
               : 이미 해당 프로젝트에 참여하고 있는지 조건이 있었음 수정 필요x
 
- 조회에서의 변화
   - 내가 북마크한 문서 조회 
          : 나갈 때 북마크 다 삭제함 수정 필요x!
   - 내가 작성한 문서 조회
          : **수정 했음** -> 해당 프로젝트에 참여하고 있는지를 where 조건에 추가
   
2. 노트 조회시 정렬 기준을 modifiedAt->createdAt