### PR TITLE
유저가 참여하지 않은 프로젝트의 노트 RUD관련 예외처리

### DIFF
--- a/src/main/java/com/example/teampandanback/controller/NoteController.java
+++ b/src/main/java/com/example/teampandanback/controller/NoteController.java
@@ -22,10 +22,10 @@ public class NoteController {
     private final NoteService noteService;
 
     //노트 칸반형 조회
-    @ApiOperation(value = "노트 칸반형 조회")
+    @ApiOperation(value = "노트 칸반형 조회", notes = "프로젝트 참여자만 조회 가능")
     @GetMapping("/projects/{projectId}/kanbans")
-    public KanbanNoteSearchResponseDto kanbanNoteSearchResponse(@PathVariable("projectId") Long projectId) {
-        return noteService.readKanbanNote(projectId);
+    public KanbanNoteSearchResponseDto kanbanNoteSearchResponse(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return noteService.readKanbanNote(projectId, userDetails.getUser());
     }
 
     //내가 쓴 노트 조회
@@ -43,14 +43,14 @@ public class NoteController {
     }
 
     //노트 상세 조회
-    @ApiOperation(value = "노트 상세 조회")
+    @ApiOperation(value = "노트 상세 조회", notes = "해당 노트가 있는 프로젝트의 참여자만 조회 가능")
     @GetMapping("/notes/{noteId}")
     public NoteDetailResponseDto noteDetail(@PathVariable("noteId") Long noteId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return noteService.readNoteDetail(noteId, userDetails.getUser());
     }
 
     //내가 생성
-    @ApiOperation(value = "노트 생성")
+    @ApiOperation(value = "노트 생성", notes = "프로젝트 참여자만 생성 가능")
     @PostMapping("/notes/{projectId}")
     public NoteCreateResponseDto createNote(@PathVariable Long projectId,
                                             @RequestBody NoteCreateRequestDto noteCreateRequestDto,
@@ -59,7 +59,7 @@ public class NoteController {
     }
 
     //노트 상세 조회에서 수정
-    @ApiOperation(value = "노트 상세 조회에서 수정")
+    @ApiOperation(value = "노트 상세 조회에서 수정", notes = "해당 노트가 있는 프로젝트의 참여자라면 모두 수정 가능")
     @PutMapping("/notes/details/{noteId}")
     public NoteUpdateResponseDto updateNote(@PathVariable("noteId") Long noteId,
                                             @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody NoteUpdateRequestDto noteUpdateRequestDto) {
@@ -68,29 +68,31 @@ public class NoteController {
     }
 
     //칸반형 조회 화면에서 노트 이동하여 수정
-    @ApiOperation(value = "칸반형 조회 화면에서 노트 이동하여 수정")
+    @ApiOperation(value = "칸반형 조회 화면에서 노트 이동하여 수정", notes = "해당 노트가 있는 프로젝트의 참여자라면 모두 이동 가능")
     @PutMapping("/notes/{noteId}")
-    public NoteUpdateResponseDto moveNote(@PathVariable("noteId") Long noteId, @RequestBody NoteMoveRequestDto noteMoveRequestDto) {
-        return noteService.moveNote(noteId, noteMoveRequestDto);
+    public NoteUpdateResponseDto moveNote(@PathVariable("noteId") Long noteId, @RequestBody NoteMoveRequestDto noteMoveRequestDto,
+                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return noteService.moveNote(noteId, noteMoveRequestDto, userDetails.getUser());
         //  서비스의 메소드명은 변경될수있습니다.
     }
 
     //노트 삭제
-    @ApiOperation(value = "노트 삭제")
+    @ApiOperation(value = "노트 삭제", notes = "해당 노트가 있는 프로젝트의 참여자라면 모두 삭제 가능")
     @DeleteMapping("/notes/{noteId}")
-    public NoteDeleteResponseDto deleteNote(@PathVariable("noteId") Long noteId) {
-        return noteService.deleteNote(noteId);
+    public NoteDeleteResponseDto deleteNote(@PathVariable("noteId") Long noteId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return noteService.deleteNote(noteId, userDetails.getUser());
     }
 
     //노트 일반형 조회
-    @ApiOperation(value = "노트 일반형 조회")
+    @ApiOperation(value = "노트 일반형 조회", notes = "해당 노트가 있는 프로젝트의 참여자만 조회 가능")
     @GetMapping("/projects/{projectId}/issues")
-    public NoteSearchResponseDto ordinaryNoteSearch(@PathVariable("projectId") Long projectId, @RequestParam("page") int page, @RequestParam("size") int size) {
-        return noteService.readOrdinaryNote(projectId, page, size);
+    public NoteSearchResponseDto ordinaryNoteSearch(@PathVariable("projectId") Long projectId, @RequestParam("page") int page,
+                                                    @RequestParam("size") int size, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return noteService.readOrdinaryNote(projectId, page, size, userDetails.getUser());
     }
 
     // 전체 프로젝트에서 내가 작성한 노트 조회
-    @ApiOperation(value = "전체 프로젝트에서 내가 작성한 노트 조회")
+    @ApiOperation(value = "전체 프로젝트에서 내가 작성한 노트 조회", notes = "유저가 썼더라도 지금은 프로젝트에 참여하지 않고 있다면 조회 불가능")
     @GetMapping("/notes/mynotes")
     public NoteMineInTotalResponseDto readMyNoteInTotalProject(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam("page") int page, @RequestParam("size") int size) {
         return noteService.readMyNoteInTotalProject(userDetails.getUser(), page, size);

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryImpl.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryImpl.java
@@ -153,13 +153,13 @@ public class NoteRepositoryImpl implements NoteRepositoryQuerydsl {
     }
 
     @Override
-    public CustomPageImpl<Note> findAllByProjectOrderByModifiedAtDesc(Project project, Pageable pageable) {
+    public CustomPageImpl<Note> findAllByProjectOrderByCreatedAtDesc(Project project, Pageable pageable) {
         QueryResults<Note> results =
                 queryFactory
                         .select(note)
                         .from(note)
                         .where(note.project.eq(project))
-                        .orderBy(note.modifiedAt.desc())
+                        .orderBy(note.createdAt.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetchResults();

--- a/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryQuerydsl.java
+++ b/src/main/java/com/example/teampandanback/domain/note/NoteRepositoryQuerydsl.java
@@ -34,7 +34,7 @@ public interface NoteRepositoryQuerydsl {
 
     List<Note> findNotesByNoteIdList(List<Long> noteIdList);
 
-    CustomPageImpl<Note> findAllByProjectOrderByModifiedAtDesc(Project project, Pageable pageable);
+    CustomPageImpl<Note> findAllByProjectOrderByCreatedAtDesc(Project project, Pageable pageable);
 
     List<Note> findAllByProjectId(Long projectId);
 

--- a/src/main/java/com/example/teampandanback/dto/note/request/NoteCreateRequestDto.java
+++ b/src/main/java/com/example/teampandanback/dto/note/request/NoteCreateRequestDto.java
@@ -3,10 +3,12 @@ package com.example.teampandanback.dto.note.request;
 import com.example.teampandanback.dto.file.request.FileDetailRequestDto;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 public class NoteCreateRequestDto {
     private String title;
     private String content;

--- a/src/main/java/com/example/teampandanback/service/NoteService.java
+++ b/src/main/java/com/example/teampandanback/service/NoteService.java
@@ -47,12 +47,20 @@ public class NoteService {
     // Note 상세 조회
     @Transactional
     public NoteDetailResponseDto readNoteDetail(Long noteId, User currentUser) {
+        // Note 조회
         NoteResponseDto noteResponseDto = noteRepository.findByNoteId(noteId)
                 .orElseThrow(() -> new ApiRequestException("작성된 노트가 없습니다."));
 
+        // 노트가 유저가 참여하고 있는 Project 에 있는지 확인
+        userProjectMappingRepository
+                .findByUserIdAndProjectId(currentUser.getUserId(), noteResponseDto.getProjectId())
+                .orElseThrow(() -> new ApiRequestException("노트가 있는 프로젝트에 소속된 유저가 아닙니다."));
+
+        // 유저가 노트를 북마크 했는지 여부
         Optional<Bookmark> bookmark = bookmarkRepository.findByUserIdAndNoteId(currentUser.getUserId(), noteId);
         noteResponseDto.setBookmark(bookmark.isPresent());
 
+        // 노트에 있는 파일 조회
         List<File> fileList = fileRepository.findFilesByNoteId(noteId);
         List<FileDetailResponseDto> fileDetailResponseDtoList = new ArrayList<>();
         for (File fileUnit : fileList) {
@@ -67,6 +75,11 @@ public class NoteService {
     public NoteUpdateResponseDto updateNoteDetail(Long noteId, User currentUser, NoteUpdateRequestDto noteUpdateRequestDto) {
         Note note = noteRepository.findById(noteId)
                 .orElseThrow(() -> new ApiRequestException("수정 할 노트가 없습니다."));
+
+        // 수정하려는 노트가 유저가 참여하고 있는 Project 에 있는지 확인
+        userProjectMappingRepository
+                .findByUserIdAndProjectId(currentUser.getUserId(), note.getProject().getProjectId())
+                .orElseThrow(() -> new ApiRequestException("노트가 있는 프로젝트에 소속된 유저가 아니여서 노트를 수정하실 수 없습니다."));
 
         List<FileDetailRequestDto> files = new ArrayList<>(noteUpdateRequestDto.getFiles());
         files.stream()
@@ -93,10 +106,15 @@ public class NoteService {
 
     // Note 칸반 이동 시 순서 업데이트
     @Transactional
-    public NoteUpdateResponseDto moveNote(Long noteId, NoteMoveRequestDto noteMoveRequestDto) {
+    public NoteUpdateResponseDto moveNote(Long noteId, NoteMoveRequestDto noteMoveRequestDto, User currentUser) {
 
         // 수정하려는 노트가 존재하지 않으면 Exception 반환.
         Note currentNote = noteRepository.findById(noteId).orElseThrow(() -> new ApiRequestException("수정하려는 노트가 존재하지 않음"));
+
+        // 수정하려는 노트가 유저가 참여하고 있는 Project 에 있는지 확인
+        userProjectMappingRepository
+                .findByUserIdAndProjectId(currentUser.getUserId(), currentNote.getProject().getProjectId())
+                .orElseThrow(() -> new ApiRequestException("노트가 있는 프로젝트에 소속된 유저가 아니여서 노트를 이동하실 수 없습니다."));
 
         // Project로 전체 노트 리스트 가져오기
         List<Note> rawNoteList = noteRepository.findByProject(currentNote.getProject());
@@ -225,10 +243,10 @@ public class NoteService {
     // 해당 Project 에서 내가 작성한 Note 조회
     public NoteMineInProjectResponseDto readNotesMineOnly(Long projectId, User currentUser, int page, int size) {
 
-        // Project 조회
-        projectRepository.findById(projectId).orElseThrow(
-                () -> new ApiRequestException("내가 작성한 문서를 조회할 프로젝트가 없습니다.")
-        );
+        // 유저가 참여하고 있는 Project 인지 확인, 해당 Project 가 실제 존재하는지도 함께 확인 가능
+        userProjectMappingRepository
+                .findByUserIdAndProjectId(currentUser.getUserId(), projectId)
+                .orElseThrow(() -> new ApiRequestException("해당 프로젝트에 소속된 유저가 아닙니다."));
 
         // 해당 Project 에서 내가 작성한 Note 조회
         CustomPageImpl<Note> noteCustomPage = noteRepository.findAllNoteByProjectAndUserOrderByCreatedAtDesc(
@@ -255,11 +273,17 @@ public class NoteService {
 
     // Note 삭제
     @Transactional
-    public NoteDeleteResponseDto deleteNote(Long noteId) {
+    public NoteDeleteResponseDto deleteNote(Long noteId, User currentUser) {
+
         // 삭제할 Note 조회
         Note note = noteRepository.findById(noteId).orElseThrow(
                 () -> new ApiRequestException("이미 삭제된 노트입니다.")
         );
+
+        // 삭제할 Note 가 유저가 참여하고 있는 Project 에 있는지 확인
+        userProjectMappingRepository
+                .findByUserIdAndProjectId(currentUser.getUserId(), note.getProject().getProjectId())
+                .orElseThrow(() -> new ApiRequestException("노트가 있는 프로젝트에 소속된 유저가 아니여서 노트를 삭제하실 수 없습니다."));
 
         //Note에 연관된 파일 삭제
         fileRepository.deleteFileByNoteId(noteId);
@@ -300,15 +324,15 @@ public class NoteService {
 
     // Note 칸반형 조회 (칸반 페이지)
     @Transactional
-    public KanbanNoteSearchResponseDto readKanbanNote(Long projectId) {
+    public KanbanNoteSearchResponseDto readKanbanNote(Long projectId, User currentUser) {
 
-        // Project 조회
-        Project project = projectRepository.findById(projectId).orElseThrow(
-                () -> new ApiRequestException("칸반을 조회할 프로젝트가 없습니다.")
-        );
+        // 유저가 참여하고 있는 Project 인지 확인, 해당 Project 가 실제 존재하는지도 함께 확인 가능
+        UserProjectMapping userProjectMapping = userProjectMappingRepository
+                .findByUserIdAndProjectId(currentUser.getUserId(), projectId)
+                .orElseThrow(() -> new ApiRequestException("해당 프로젝트에 소속된 유저가 아닙니다."));
 
         // Project로 전체 노트 리스트 가져오기
-        List<Note> rawNoteList = noteRepository.findByProject(project);
+        List<Note> rawNoteList = noteRepository.findByProject(userProjectMapping.getProject());
 
         // topNoteList 만들기, <PK,Note> 해쉬맵 만들기 (실은 순회 한 번에 할 수 있음, 지금은 2번) -> 수정 시 재사용 가능
         List<Note> topNoteList = pandanUtils.getTopNoteList(rawNoteList);
@@ -335,15 +359,16 @@ public class NoteService {
 
     // Note 일반형 조회 (파일 페이지)
     @Transactional
-    public NoteSearchResponseDto readOrdinaryNote(Long projectId, int page, int size) {
+    public NoteSearchResponseDto readOrdinaryNote(Long projectId, int page, int size, User currentUser) {
         List<OrdinaryNoteEachResponseDto> ordinaryNoteEachResponseDtoList = new ArrayList<>();
 
-        // Project 조회
-        Project project = projectRepository.findById(projectId).orElseThrow(
-                () -> new ApiRequestException("파일을 조회할 프로젝트가 없습니다.")
-        );
+        // 유저가 참여하고 있는 Project 인지 확인, 해당 Project 가 실제 존재하는지도 함께 확인 가능
+        UserProjectMapping userProjectMapping = userProjectMappingRepository
+                .findByUserIdAndProjectId(currentUser.getUserId(), projectId)
+                .orElseThrow(() -> new ApiRequestException("해당 프로젝트에 소속된 유저가 아닙니다."));
+
         CustomPageImpl<Note> ordinaryNoteCustomPage = noteRepository.findAllByProjectOrderByModifiedAtDesc(
-                project, pandanUtils.dealWithPageRequestParam(page, size));
+                userProjectMapping.getProject(), pandanUtils.dealWithPageRequestParam(page, size));
 
         for (Note note : ordinaryNoteCustomPage.toList()) {
             ordinaryNoteEachResponseDtoList.add((OrdinaryNoteEachResponseDto.fromEntity(note)));


### PR DESCRIPTION
유저가 참여하지 않은 프로젝트의 노트 조회, 수정, 삭제관련 예외 처리를 하였습니다. [#109 ]

AS-IS)
노트를 조회, 수정, 삭제할 수 있는 사람은 작성자 뿐만 아니라 모두가 가능하다.

문제점)
진짜 모두가 가능하다. 유저가 참여하지 않은 프로젝트에 대해서도 모든 조회, 수정, 삭제가 가능하다.

TO-BE)
노트를 조회, 수정, 삭제할 수 있는 사람은 작성자 뿐만 아니라 **프로젝트 참여자 내에서 모두가 가능**하다.
내가 참여하지 않은 프로젝트라면,
- 노트 수정 불가능
- 노트 이동 불가능
- 노트 삭제 불가능
- 노트 조회 불가능
    - 칸반형 목록 조회
    - 일반형 목록 조회
    - 프로젝트 내에서 내가 작성한 노트 목록 조회
    - 노트 상세 조회